### PR TITLE
Added params needed to set up code manager

### DIFF
--- a/pe.conf
+++ b/pe.conf
@@ -10,7 +10,9 @@
   #--------------------------------------------------------------------------
   # Required. The password to log into the Puppet Enterprise console.
   #--------------------------------------------------------------------------
-  "console_admin_password": "ラリッサ"
+  "console_admin_password": "ラリッサ",
+  "puppet_enterprise::profile::master::code_manager_auto_configure": true,
+  "puppet_enterprise::profile::master::r10k_remote": "https://github.com/beergeek/utf_8_test.git",
 
 
   #--------------------------------------------------------------------------


### PR DESCRIPTION
The setup script didn't work because code-staging and other code manager stuff was not getting created. This fixes that
